### PR TITLE
JMess.d.ts typescript definition changes

### DIFF
--- a/jMess.Build/output/jMess.d.ts
+++ b/jMess.Build/output/jMess.d.ts
@@ -21,6 +21,7 @@ declare module jMess {
 declare module jMess {
     interface IEventRegistry {
         getAvailableEvents(): string[];
+        getHooksForEvent<T>(eventName: string): { (data: T): void; }[];
         hook<T>(eventName: string, onRaise: (data: T) => void): () => void;
         hookOnce<T>(eventToHook: string, delegate: (data: T) => void): any;
         raise<T>(eventToRaise: string, data: T): void;

--- a/jMess.Build/output/jMess.d.ts
+++ b/jMess.Build/output/jMess.d.ts
@@ -21,9 +21,9 @@ declare module jMess {
 declare module jMess {
     interface IEventRegistry {
         getAvailableEvents(): string[];
-        register(eventsToRegister: any): void;
         hook<T>(eventName: string, onRaise: (data: T) => void): () => void;
         hookOnce<T>(eventToHook: string, delegate: (data: T) => void): any;
         raise<T>(eventToRaise: string, data: T): void;
+        register(eventsToRegister: string | string[] | Object): void;
     }
 }

--- a/jMess.Build/output/jMess.d.ts
+++ b/jMess.Build/output/jMess.d.ts
@@ -7,10 +7,10 @@ declare module jMess {
         private _onRaise;
         constructor(logR: ILogR, onRaise: (event: string, data: Object) => void, timeout?: (delegate: () => void, delay: number) => void);
         getAvailableEvents(): string[];
-        getHooksForEvent(eventName: string): Function[];
-        hook(eventToHook: string, delegate: Function): () => void;
-        hookOnce(eventToHook: string, delegate: Function): void;
-        raise(eventToRaise: string, data: Object): void;
+        getHooksForEvent<T>(eventName: string): { (data: T): void; }[];
+        hook<T>(eventToHook: string, delegate: (data: T) => void): () => void;
+        hookOnce<T>(eventToHook: string, delegate: (data: T) => void): void;
+        raise<T>(eventToRaise: string, data: T): void;
         register(eventsToRegister: string | string[] | Object): void;
         private _registerEventsObject(eventsObj);
         private _registerArrayOfEvents(eventsArray);
@@ -21,9 +21,9 @@ declare module jMess {
 declare module jMess {
     interface IEventRegistry {
         getAvailableEvents(): string[];
-        hook(eventName: string, onRaise: Function): () => void;
-        hookOnce(eventToHook: string, delegate: Function): any;
-        raise(eventToRaise: string, data: Object): void;
         register(eventsToRegister: any): void;
+        hook<T>(eventName: string, onRaise: (data: T) => void): () => void;
+        hookOnce<T>(eventToHook: string, delegate: (data: T) => void): any;
+        raise<T>(eventToRaise: string, data: T): void;
     }
 }


### PR DESCRIPTION
I've added generics to the type definitions, these will not cause breaking changes, they are optional.  

This will allow me to do things like raise events in a type safe way without casting.

For example, this:
``` typescript
this.eventRegistry.raise(AuthenticatedUserEvents.ExpenseListRequest, <IExpenseListRequest>{});
```

Can become this:
``` typescript
this.eventRegistry.raise<IExpenseListRequest>(AuthenticatedUserEvents.ExpenseListRequest, {});
```